### PR TITLE
remove Badge background and ⚠️ ->📏

### DIFF
--- a/javascript/aspectRatioSliders.js
+++ b/javascript/aspectRatioSliders.js
@@ -18,8 +18,8 @@ class AspectRatioSliderController {
         }
         //Adjust badge icon if rounding is on
         if (this.roundingSource.getVal()) {
-            this.roundingIndicatorBadge.classList.add("active");
-            this.roundingIndicatorBadge.innerText = "⚠️";
+            //this.roundingIndicatorBadge.classList.add("active");
+            this.roundingIndicatorBadge.innerText = "📏";
         }
         //Make badge clickable to toggle setting
         this.roundingIndicatorBadge.addEventListener("click", () => {
@@ -28,11 +28,11 @@ class AspectRatioSliderController {
         //Make rounding setting toggle badge text and style if setting changes
         this.roundingSource.child.addEventListener("change", () => {
             if (this.roundingSource.getVal()) {
-                this.roundingIndicatorBadge.classList.add("active");
-                this.roundingIndicatorBadge.innerText = "⚠️";
+                //this.roundingIndicatorBadge.classList.add("active");
+                this.roundingIndicatorBadge.innerText = "📏";
             }
             else {
-                this.roundingIndicatorBadge.classList.remove("active");
+                //this.roundingIndicatorBadge.classList.remove("active");
                 this.roundingIndicatorBadge.innerText = "📐";
             }
             this.adjustStepSize();

--- a/style.css
+++ b/style.css
@@ -776,7 +776,7 @@ footer {
 .rounding-badge {
   display: inline-block;
   border-radius: 0px;
-  background-color: #ccc;
+  /*background-color: #ccc;*/
   cursor: pointer;
   position: absolute;
   top: -10px;


### PR DESCRIPTION
AUTO is rather particular about the UI

and in my opinion the Badge background color clutters up the interface
the shape changing is also distracting

theres also the issue is that the warning icon Emoji is not render properly on Chrome for some reason (tested on PC and my Phone)
and I don't think warning is a good icon in the first place, it should be inexact
so I switch ⚠️to📏
think of like taking measurement with a Hand Squares is more accurate Ruler

before and after comparison
![2023-02-10 08_41_49-Stable Diffusion 007014](https://user-images.githubusercontent.com/40751091/217963717-9919b9ee-d7d1-471c-8cb8-2c05644fff9d.png)![2023-02-10 08_41_56-Stable Diffusion 007015](https://user-images.githubusercontent.com/40751091/217963715-49aed9b5-fe4e-4e8a-886d-60cf9e8f887d.png)

![2023-02-10 08_31_21-Stable Diffusion 007013](https://user-images.githubusercontent.com/40751091/217963408-b0a0765f-d11c-4d70-adf9-b9d8160196a4.png)![2023-02-10 08_31_13-Stable Diffusion 007012](https://user-images.githubusercontent.com/40751091/217963412-0adec412-4ac5-4dc9-8e67-3ea3485bbd28.png)
